### PR TITLE
Fix bug with commits with "

### DIFF
--- a/send.ps1
+++ b/send.ps1
@@ -37,8 +37,8 @@ if (!$env:APPVEYOR_REPO_COMMIT) {
 
 $AUTHOR_NAME="$(git log -1 "$env:APPVEYOR_REPO_COMMIT" --pretty="%aN")"
 $COMMITTER_NAME="$(git log -1 "$env:APPVEYOR_REPO_COMMIT" --pretty="%cN")"
-$COMMIT_SUBJECT="$(git log -1 "$env:APPVEYOR_REPO_COMMIT" --pretty="%s")"
-$COMMIT_MESSAGE="$(git log -1 "$env:APPVEYOR_REPO_COMMIT" --pretty="%b")"
+$COMMIT_SUBJECT="$(git log -1 "$env:APPVEYOR_REPO_COMMIT" --pretty="%s")" -replace "`"", "'"
+$COMMIT_MESSAGE="$(git log -1 "$env:APPVEYOR_REPO_COMMIT" --pretty="%b")" -replace "`"", "'"
 
 if ($AUTHOR_NAME -eq $COMMITTER_NAME) {
   $CREDITS="$AUTHOR_NAME authored & committed"


### PR DESCRIPTION
Having quotation marks in a commit subject or message causes the webhook to fail sending entirely. This fix replaces " with ', thereby allowing the webhook to send better (attempting to replace with "```"" did not fix the issue, so this is the best I got)